### PR TITLE
Fix to set None as old AT content type UID before object is deleted

### DIFF
--- a/Products/contentmigration/basemigrator/migrator.py
+++ b/Products/contentmigration/basemigrator/migrator.py
@@ -50,6 +50,10 @@ try:
     IRedirectionStorage  # pyflakes
 except ImportError:
     IRedirectionStorage = None
+try:
+    from Products.Archetypes.config import UUID_ATTR
+except ImportError:
+    UUID_ATTR = None
 
 LOG = logging.getLogger('ATCT.migration')
 
@@ -621,6 +625,8 @@ class UIDMigrator(object):
             return  # old object doesn't support AT uuids
         uid = self.old.UID()
         self.old._uncatalogUID(self.parent)
+        if UUID_ATTR:  # Prevent object deletion triggering UID related magic
+            setattr(self.old, UUID_ATTR, None)
         if queryAdapter(self.new, IMutableUUID):
             IMutableUUID(self.new).set(str(uid))
         else:


### PR DESCRIPTION
@pbauer Do you remember having any AT relations issues with the current p.a.contenttypes migration? This patch of removing the UID from the old object before it's been deleted and all deletion related events are triggered was required for me to avoid resulting broken relations_catalog after the migration (it was full of relations pointing to MIGRATION-objects).

I'm haven't tested this outside my own migrations yet.
