### PR TITLE
Unpack brains to be able to log broken catalog-records during migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Unpack brains to be able to log broken catalog-records during migration.
+  [pbauer]
 
 
 2.1.16 (2017-03-09)

--- a/Products/contentmigration/basemigrator/walker.py
+++ b/Products/contentmigration/basemigrator/walker.py
@@ -269,11 +269,17 @@ class CatalogWalker(Walker):
         if limit:
             brains = brains[:limit]
 
+        # unpack to be able to log brains that break during migration
+        brains = [i for i in brains]
+
         for brain in brains:
             try:
                 obj = brain.getObject()
             except AttributeError:
                 LOG.error("Couldn't access %s" % brain.getPath())
+                continue
+            except KeyError:
+                LOG.error("Couldn't access RID %s" % brain.getRID())
                 continue
             try:
                 state = obj._p_changed

--- a/Products/contentmigration/walker.py
+++ b/Products/contentmigration/walker.py
@@ -59,11 +59,17 @@ class CustomQueryWalker(CatalogWalker):
         if limit:
             brains = brains[:limit]
 
+        # unpack to be able to log brains that break during migration
+        brains = [i for i in brains]
+
         for brain in brains:
             try:
                 obj = brain.getObject()
             except AttributeError:
                 LOG.error("Couldn't access %s" % brain.getPath())
+                continue
+            except KeyError:
+                LOG.error("Couldn't access RID %s" % brain.getRID())
                 continue
 
             if self.callBefore is not None and callable(self.callBefore):


### PR DESCRIPTION
This works around a issue with a brain that could not be accessed when migrating topics from AT to DX in Plone 5. And yes: The catalog was rebuild and up-to-date before the migration. 

This way the migration can finish and the brain can be inspected afterwards with the RID from the log.

```
2017-08-29 18:46:33 ERROR Zope.SiteErrorLog 1504025193.720.716476024569 http://localhost:8080/nm/portal_setup/manage_doUpgrades
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module Products.PDBDebugMode.runcall, line 70, in pdb_runcall
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module netstal.policy.upgrades, line 799, in migrate_topics
  Module plone.app.contenttypes.migration.browser, line 183, in __call__
  Module plone.app.contenttypes.migration.topics, line 709, in migrate_topics
  Module Products.contentmigration.basemigrator.walker, line 144, in go
  Module Products.contentmigration.basemigrator.walker, line 177, in migrate
  Module Products.contentmigration.walker, line 62, in walk
  Module Products.ZCatalog.Lazy, line 190, in __getitem__
  Module Products.ZCatalog.Catalog, line 122, in __getitem__
KeyError: -1983529389
```
