### PR TITLE
Prevent installation on Py 3, where Archetypes does not work.

### DIFF
--- a/news/3330.bugfix
+++ b/news/3330.bugfix
@@ -1,0 +1,2 @@
+Prevent installation on Python 3, as we know Archetypes does not work there.
+[maurits]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ ignore =
     *.cfg
     bootstrap.py
 
-
-
 [bdist_wheel]
-universal = 1
+# Py2 only
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,12 @@
 from setuptools import setup, find_packages
 
+import sys
+
+
+if sys.version_info[0] != 2:
+    # Prevent creating or installing a distribution with Python 3.
+    raise ValueError("Products.contentmigration is based on Archetypes, which is Python 2 only.")
+
 version = '2.2.2.dev0'
 
 setup(
@@ -12,14 +19,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Framework :: Plone",
         "Framework :: Plone :: 5.2",
-        "Framework :: Plone :: 6.0",
         "Framework :: Plone :: Core",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
     ],
     keywords='Plone Archetypes ATContentTypes',
     author='Martin Aspeli (and others)',
@@ -30,6 +33,7 @@ setup(
     namespace_packages=['Products'],
     include_package_data=True,
     zip_safe=False,
+    python_requires='==2.7.*',
     extras_require=dict(
         test=[
             'archetypes.schemaextender',


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/3330

I did not realise at first that `Products.contentmigration` is only for Archetypes.  Or am I mistaken?

I think there used to be code for dexterity as well, but maybe this has been moved to `plone.app.contenttypes`. When I grep for `dexterity` or `plone.app.contenttypes`, I find nothing.
When you add this package to the eggs in Python 3, buildout succeeds (without this PR anyway) and the instance starts. But most modules give an error when importing, due to a missing `Products.Archetypes`, or implicit relative imports, or a failing import of `from cgi import escape`.

So it seems okay to actively make this not installable on Python 3.